### PR TITLE
Rails 6

### DIFF
--- a/awesome_hstore_translate.gemspec
+++ b/awesome_hstore_translate.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 5.0', '< 6'
-  spec.add_dependency 'activemodel', '>= 5.0', '< 6'
+  spec.add_dependency 'activerecord', '>= 5.0'
+  spec.add_dependency 'activemodel', '>= 5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/awesome_hstore_translate/active_record/query_methods.rb
+++ b/lib/awesome_hstore_translate/active_record/query_methods.rb
@@ -62,7 +62,15 @@ module AwesomeHstoreTranslate
       end
 
       def untranslated_attributes(opts)
+        return safe_untranslated_attributes(opts) if opts.is_a?(Array)
+
         opts.reject{ |key, _| self.translated_attribute_names.include?(key) }
+      end
+
+      def safe_untranslated_attributes(opts)
+        opts
+          .reject { |opt| opt.is_a?(Arel::Nodes::Ordering) }
+          .map! { |opt| Arel.sql(opt.to_s) }
       end
     end
   end

--- a/lib/awesome_hstore_translate/version.rb
+++ b/lib/awesome_hstore_translate/version.rb
@@ -1,3 +1,3 @@
 module AwesomeHstoreTranslate
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
Rails 6 compatible.

Prevent dangerous query warning:

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL)
called with non-attribute argument(s): nil. Non-attribute arguments will be disallowed in Rails 6.1.
This method should not be called with user-provided values, such as request parameters or model attributes.
Known-safe values can be passed by wrapping them in Arel.sql().
(called from order at /lib/awesome_hstore_translate/active_record/query_methods.rb:45)
```